### PR TITLE
Removing documentation around custom styles

### DIFF
--- a/source/includes/_android.md.erb
+++ b/source/includes/_android.md.erb
@@ -207,13 +207,6 @@ Used to pass meta information about a Chatter. This can be useful for tracking i
 
 You can also set "meta fields" using XML. For this, you need to create a JSON file in the res/raw directory, and set the reference to the view declaration:
 
-#### styles
-The `styles` option can be used to override default styles inside of Web Chat. The value of the string should be the CSS rule-set you wish to apply inside the Web Chat iFrame. Note that the `ui_customization` feature flag is required to use this feature, and may not be available in all packages.
-
-<aside class="warning">
-Setting custom styles based on Chat elements is inherently brittle, and can cause your styles to break over time. We do not recommend use of custom styles unless absolutely necessary. If custom styles are used, you should only rely on direct element IDs.
-</aside>
-
 #### zdChatterAuthCallback
 
 > When using AdaEmbedView

--- a/source/includes/_embed2.md.erb
+++ b/source/includes/_embed2.md.erb
@@ -153,7 +153,7 @@ Embed1 Feature | Status | Comments
 `dragAndDrop` | Deprecated |
 `mobileOverlay` | Deprecated |
 `private` | Modified | Renamed to `privateMode`.
-`styles` | Same API | Now requires a feature flag to use.
+`styles` | Deprecated |
 
 Additionally, all actions have been modified to return Promises.
 
@@ -225,15 +225,6 @@ The Embed2 entry and client scripts must all use the same version. If you requir
 `domain?: string;`
 
 Can be used to change the subdomain. Unless directed by an Ada team member, you will not need to change this value.
-
-#### embedStyles
-`embedStyles?: string;`
-
-The embedStyles option can be used to override default styles inside Embed2 elements. The value of the string should be the CSS rule-set you wish to apply inside the iFrame. Note that the `ui_customization` feature flag is required to use this feature, and may not be available in all packages.
-
-<aside class="warning">
-Setting custom styles based on Embed2 elements is inherently brittle, and can cause your styles to break over time. We do not recommend use of custom styles unless absolutely necessary. If custom styles are used, you should only rely on direct element IDs.
-</aside>
 
 #### greeting
 `greeting?: string;`
@@ -326,15 +317,6 @@ If set to `true`, this will put Web Chat into "Private" mode. This will cause We
 `rolloutOverride?: number;`
 
 Can be used to override the rollout value set in the dashboard. This can be useful if you need page-specific rollout values. Accepts any number between `0` and `1`.
-
-#### styles
-`styles?: string;`
-
-The styles option can be used to override default styles inside the Web Chat iFrame. The value of the string should be the CSS rule-set you wish to apply inside the iFrame. Note that the `ui_customization` feature flag is required to use this feature, and may not be available in all packages.
-
-<aside class="warning">
-Setting custom styles based on Chat elements is inherently brittle, and can cause your styles to break over time. We do not recommend use of custom styles unless absolutely necessary. If custom styles are used, you should only rely on direct element IDs.
-</aside>
 
 #### testMode
 `testMode?: boolean;`
@@ -510,13 +492,9 @@ Ada now has native support for both iOS and Android apps! Find out more about iO
 
 Ada supports multiple options for button configuration through the dashboard. Without any code, you can customize attributes such as the button colour, size, and icon.
 
-Further customization can be made through the `embedStyles` setting above. CSS selectors can be brittle, and your style customizations may need to be updated from time to time. If this functionality is required, the `ui_customization` feature flag must first be turned on by an Ada ACX team member.
-
 #### How do I customize the look and feel of the Chat window?
 
 Basic branding, including colours and icons, can be configured through the Ada dashboard.
-
-Additional customization of the chat window is available through the `styles` setting, as long as you have the `ui_customization` feature flag enabled. As with `embedStyled` we do not recommend using this feature unless crucial.
 
 #### Ada Embed is rendered as soon as the page loads. How can I delay rendering?
 

--- a/source/includes/_ios.md.erb
+++ b/source/includes/_ios.md.erb
@@ -100,15 +100,6 @@ Used to pass meta information about a Chatter. This can be useful for tracking i
 
 External web links now open by default in-app via the SFSafariViewController. To open external links in the Safari browser, pass `openWebLinksInSafari: true` to `AdaWebHost`.
 
-#### styles
-`styles: String = ""`
-
-The styles option can be used to override default styles inside of Web Chat. The value of the string should be the CSS rule-set you wish to apply inside the Web Chat iFrame. Note that the `ui_customization` feature flag is required to use this feature, and may not be available in all packages.
-
-<aside class="warning">
-Setting custom styles based on Chat elements is inherently brittle, and can cause your styles to break over time. We do not recommend use of custom styles unless absolutely necessary. If custom styles are used, you should only rely on direct element IDs.
-</aside>
-
 #### zdChatterAuthCallback
 `zdChatterAuthCallback: ((((_ token: String) -> Void)) -> Void)? = nil`
 

--- a/source/includes/_reactnative.md.erb
+++ b/source/includes/_reactnative.md.erb
@@ -99,15 +99,6 @@ metaFields={{
 
 Used to pass meta information about a `chatter`. This can be useful for tracking information about your end users, as well as for personalizing their experience. For example, you may wish to track the phone_number and name for conversation attribution. Once set, this information can be accessed in the email attachment from Handoff Form submissions, or via the Chatter modal in the Conversations page of your Ada dashboard. Should you need to programatically change these values after bot setup, you can make use of the [setMetaFields](#setmetafields_-fields-string-any) method below.
 
-#### styles
-`styles?: string;`
-
-The styles option can be used to override default styles inside of Web Chat. The value of the string should be the CSS rule-set you wish to apply inside the Web Chat iFrame. Note that the `ui_customization` feature flag is required to use this feature, and may not be available in all packages.
-
-<aside class="warning">
-Setting custom styles based on Chat elements is inherently brittle, and can cause your styles to break over time. We do not recommend use of custom styles unless absolutely necessary. If custom styles are used, you should only rely on direct element IDs.
-</aside>
-
 #### thirdPartyCookiesEnabled (Android)
 `thirdPartyCookiesEnabled?: boolean;`
 


### PR DESCRIPTION
We are no longer supporting custom embed styles - this is to remove the documentation around it.