### PR TITLE
Update android sdk version in docs to 1.3.8

### DIFF
--- a/source/includes/_android.md.erb
+++ b/source/includes/_android.md.erb
@@ -45,13 +45,13 @@ To integrate the SDK, first add the following code to the project level `build.g
 > If your project has artifacts within the AndroidX namespace, use:
 
 ```groovy
-implementation 'support.ada.embed:android-sdk-appcompat:1.3.7'
+implementation 'support.ada.embed:android-sdk-appcompat:1.3.8'
 ```
 
 > If your project uses Android Support Library, use:
 
 ```groovy
-implementation 'support.ada.embed:android-sdk-appcompat-legacy:1.3.7'
+implementation 'support.ada.embed:android-sdk-appcompat-legacy:1.3.8'
 ```
 
 > Be sure to get the latest version at [https://gitlab.com/adasupport/androidsdk/-/packages](https://gitlab.com/adasupport/androidsdk/-/packages).


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

recently updated version in this pr: https://github.com/AdaSupport/AndroidSDK/pull/24 , so updating the docs to match